### PR TITLE
chore: rename package from llm_utils to aiweb-common

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "llm_utils"
+name = "aiweb-common"
 version = "0.1.0"
 description = "PoC"
 requires-python = ">=3.11"


### PR DESCRIPTION
Align the PyPI/pip package name with the actual importable module (aiweb_common). Downstream projects can now use:

  aiweb-common @ git+https://github.com/UABPeriopAI/llm_utils.git@develop

and `import aiweb_common` works without confusion.