### PR TITLE
Wrap PubMedQuery response with extract_response_text

### DIFF
--- a/aiweb_common/resource/PubMedQuery.py
+++ b/aiweb_common/resource/PubMedQuery.py
@@ -1,6 +1,6 @@
 from aiweb_common.generate.SingleResponse import SingleResponseHandler
 from aiweb_common.resource import default_resource_config
-from aiweb_common.WorkflowHandler import WorkflowHandler
+from aiweb_common.WorkflowHandler import WorkflowHandler, extract_response_text
 
 
 class PubMedQueryGenerator(WorkflowHandler):
@@ -42,4 +42,4 @@ class PubMedQueryGenerator(WorkflowHandler):
         response, response_meta = self.single_response.generate_response(assembled_prompt)
         self._update_total_cost(response_meta)
 
-        return response.content
+        return extract_response_text(response.content)


### PR DESCRIPTION
## Summary
- Wraps `response.content` return in `PubMedQueryGenerator.generate_search_string()` with `extract_response_text()` so it works with both Chat Completions API (str) and Responses API (list[dict])
- Without this, GPT-5 models return a list that breaks downstream PubMed search calls

## Test plan
- [x] Verify PubMed search works with gpt-4o (backwards compat)
- [x] Verify PubMed search works with gpt-5 (Responses API path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)