### PR TITLE
Remove unused promptflow and prompty dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ dependencies = [
   "streamlit",
   "pandas",
   "pyodbc",
-  "prompty",
-  "promptflow",
   "langchain_core",
   "langchain_community",
   "langchain_openai",


### PR DESCRIPTION
## Summary

- Removes `promptflow` and `prompty` from `[project.dependencies]` in pyproject.toml

## Why

Neither package is imported anywhere in the codebase:

```
grep -r "import promptflow\|from promptflow" --include="*.py"  → 0 results
grep -r "import prompty\|from prompty" --include="*.py"         → 0 results
```

`promptflow` transitively depends on `promptflow-devkit`, which requires `pandas>=1.5.3,<3.0.0`. This blocks any downstream project that needs `pandas>=3` — specifically, Grant_Editor now depends on `academic-refchecker` which requires `pandas>=3.0.2`. The dependency conflict makes `uv sync` (and `pip install`) fail.

**Note:** `langchain_prompty` (which IS used by `PromptyServicer.py`) is a separate package and is retained.

## Test plan

- [x] `uv sync` resolves without errors
- [x] Existing tests pass (promptflow was never called)
- [x] Grant_Editor can install both `aiweb-common` and `academic-refchecker` together

🤖 Generated with [Claude Code](https://claude.com/claude-code)